### PR TITLE
Add site-wide under construction overlay

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -28,3 +28,46 @@
 <link rel="icon" type="image/png" sizes="32x32" href="{{ site.baseurl }}/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="{{ site.baseurl }}/favicon-16x16.png">
 <link rel="manifest" href="{{ site.baseurl }}/site.webmanifest">
+
+<!-- Site-wide "under construction" notice -->
+<style>
+  #under-construction-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2147483647;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #0f0f0f;
+    color: #f5f5f5;
+    text-align: center;
+    padding: 24px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  #under-construction-overlay .uc-inner {
+    max-width: 620px;
+  }
+  #under-construction-overlay h1 {
+    font-size: clamp(28px, 6vw, 52px);
+    letter-spacing: 0.04em;
+    margin: 0 0 0.5em;
+    text-transform: uppercase;
+  }
+  #under-construction-overlay p {
+    font-size: clamp(15px, 2.4vw, 20px);
+    line-height: 1.6;
+    margin: 0;
+    opacity: 0.85;
+  }
+  /* Prevent the page behind the overlay from scrolling/peeking through */
+  html.uc-locked, html.uc-locked body {
+    overflow: hidden !important;
+  }
+</style>
+<script>document.documentElement.classList.add('uc-locked');</script>
+<div id="under-construction-overlay" role="alert" aria-live="assertive">
+  <div class="uc-inner">
+    <h1>Under Construction</h1>
+    <p>This site is currently being rebuilt. Please check back soon.</p>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
This change adds a full-screen "under construction" notice that displays across the entire site, preventing users from accessing content while the site is being rebuilt.

## Key Changes
- Added fixed-position overlay div that covers the entire viewport with a dark background
- Implemented responsive typography using CSS `clamp()` for heading and paragraph text
- Added styles to prevent page scrolling when overlay is active by locking `html` and `body` overflow
- Included semantic HTML with `role="alert"` and `aria-live="assertive"` for accessibility
- Used maximum z-index (2147483647) to ensure overlay appears above all other content
- Added inline script to immediately apply `uc-locked` class on page load, preventing layout shift

## Implementation Details
- Overlay uses `inset: 0` for full viewport coverage with `position: fixed`
- Responsive font sizing scales between minimum and maximum values based on viewport width
- System font stack ensures consistent rendering across platforms
- Message is centered both horizontally and vertically using flexbox
- Accessibility considerations include proper ARIA attributes for screen readers

https://claude.ai/code/session_01NWqXAj5i8wwiw3ei1FhPat